### PR TITLE
docs: Disable Podman logging for daemon replacement

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ With Podman (needs root permissions) (recommended):
 ```
 sudo podman run -d \
 --name incus \
+--log-driver=none \
 --cgroups=no-conmon \
 --cgroupns=host \
 --security-opt unmask=/sys/fs/cgroup \
@@ -53,6 +54,13 @@ sudo podman run -d \
 --volume /lib/modules:/lib/modules:ro \
 ghcr.io/cmspam/incus-docker:latest
 ```
+
+Incus writes its daemon and instance logs under `/var/log/incus` and exposes
+its event stream through the Incus API. Disabling Podman's log driver also
+prevents long-lived LXC monitor processes from inheriting conmon's logging
+pipe. Otherwise replacing the daemon container while guests remain running
+can leave the old conmon waiting for those guests to close that pipe.
+
 With Docker:
 
 ```


### PR DESCRIPTION
Disable Podman's log driver in the recommended Incus daemon command.

Incus already owns its logs under /var/log/incus. More importantly for live daemon replacement, an LXC monitor can inherit conmon's stdout/stderr pipe and keep the old conmon alive until the guest exits.

Validated with a running system container:
- guest init PID remained unchanged across two daemon replacements
- with journald, the first replacement waited about 142 seconds for the old conmon
- with --log-driver=none, the next replacement completed in 5 seconds and the old conmon exited immediately
- the RBD root filesystem and both network interfaces remained active